### PR TITLE
Ported to 2022 (Java)

### DIFF
--- a/java/src/main/java/com/analog/adis16470/frc/ADIS16470_IMU.java
+++ b/java/src/main/java/com/analog/adis16470/frc/ADIS16470_IMU.java
@@ -6,7 +6,6 @@
 /*----------------------------------------------------------------------------*/
 
 package com.analog.adis16470.frc;
-
 import java.lang.reflect.Array;
 //import java.lang.FdLibm.Pow;
 import java.nio.ByteBuffer;
@@ -23,21 +22,22 @@ import edu.wpi.first.hal.FRCNetComm.tResourceType;
 import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.DigitalOutput;
 import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj.GyroBase;
 import edu.wpi.first.wpilibj.SPI;
-import edu.wpi.first.wpilibj.Sendable;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.interfaces.Gyro;
-import edu.wpi.first.wpilibj.smartdashboard.SendableBuilder;
+import edu.wpi.first.networktables.NTSendable;
+import edu.wpi.first.networktables.NTSendableBuilder;
 import edu.wpi.first.networktables.NetworkTable;
 import edu.wpi.first.networktables.NetworkTableEntry;
 import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
 
 /**
  * This class is for the ADIS16470 IMU that connects to the RoboRIO SPI port.
  */
 @SuppressWarnings("unused")
-public class ADIS16470_IMU extends GyroBase implements Gyro, Sendable {
+public class ADIS16470_IMU implements Gyro, NTSendable {
   
   /* ADIS16470 Register Map Declaration */
   private static final int FLASH_CNT      =   0x00;  //Flash memory write count
@@ -977,6 +977,11 @@ public class ADIS16470_IMU extends GyroBase implements Gyro, Sendable {
    */
   public synchronized double getYFilteredAccelAngle() {
     return m_accelAngleY;
+  }
+
+  public void initSendable(NTSendableBuilder builder) {
+    builder.setSmartDashboardType("Gyro");
+    builder.addDoubleProperty("Value", this::getAngle, null);
   }
 
 }


### PR DESCRIPTION
The new version of WPILib had some breaking changes including GyroBase and breaking apart Sendable into two types. I've updated the code to build. I don't have access to a RoboRio + IMU to test, but I haven't changed any functionality, just added the NetworkTables Sender method.